### PR TITLE
Switch back and forth between last two workspaces.

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -28,6 +28,7 @@ var Monitor = function(nwm, monitor) {
   };
   // Currently focused window
   this.focused_window = null;
+  this.previous_workspace = 1;
 
   function inExactIndexOf(arr, needle) {
     var index = -1;
@@ -130,10 +131,17 @@ Monitor.prototype.go = function(workspace_id) {
   });
   var monitor = this;
   if(workspace_id != monitor.workspaces.current) {
+    monitor.previous_workspace = monitor.workspaces.current;
     monitor.workspaces.current = workspace_id;
   }
   // always rearrange
   monitor.workspaces.get(monitor.workspaces.current).rearrange();
+};
+
+Monitor.prototype.goBack = function() {
+  var cur_workspace = this.workspaces.current;
+  this.go(this.previous_workspace);
+  this.previous_workspace = cur_workspace;
 };
 
 // Move a window to a different workspace

--- a/nwm-user-sample.js
+++ b/nwm-user-sample.js
@@ -169,6 +169,12 @@ var keyboard_shortcuts = [
     callback: function() {
       process.exit();
     }
+  },
+  {
+    key: 'BackSpace',
+    callback: function() {
+      currentMonitor().goBack();
+    }
   }
 ];
 

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ That's it.
     # Workspaces
     Meta + [1..n] -- Switch to workspace n
     Meta + Shift + [1..n] -- Move window to workspace n
+    Meta + BackSpace -- Switch back and forth between the last two workspaces
 
     # Multi-monitor keys
     Meta + Shift + , -- Send focused window to previous screen


### PR DESCRIPTION
This adds support to switch between the two most recently used
workspaces along with a convenient shortcut definition: Meta+BackSpace
and a nifty documentation line in the README. This works per monitor.
